### PR TITLE
Add some idiot-proofing.

### DIFF
--- a/src/pocketnode/plugin/Plugin.js
+++ b/src/pocketnode/plugin/Plugin.js
@@ -10,13 +10,16 @@ class Plugin {
         this.arguments = [];
     }
 
-    constructor(name, description, permission, aliases, server){
+    constructor(name, description, permission, aliases, server, version, api, author){
         this.initVars();
         this.name = name;
         this.description = description;
         this.permission = permission;
         this.aliases = aliases || [];
         this.server = server;
+        this.version = version;
+        this.api = api;
+        this.author = author;
     }
 
     getName(){

--- a/src/pocketnode/plugin/PluginLoader.js
+++ b/src/pocketnode/plugin/PluginLoader.js
@@ -30,7 +30,7 @@ class PluginLoader {
             if(FileSystem.existsSync(location + "manifest.json")) {
                 var manifest = JSON.parse(FileSystem.readFileSync(location + "manifest.json").toString());
                 manifest = this.checkManifest(manifest);
-                plugins[i] = new plugins[i](manifest.name, manifest.description, manifest.permission, manifest.aliases, this.server);
+                plugins[i] = new plugins[i](manifest.name, manifest.description, manifest.permission, manifest.aliases, this.server, manifest.version, manifest.api, manifest.author);
                 this.server.getCommandMap().registerCommand(plugins[i]);
                 if(plugins[i].onEnable != null) {
                     plugins[i].onEnable();

--- a/src/pocketnode/plugin/PluginLoader.js
+++ b/src/pocketnode/plugin/PluginLoader.js
@@ -15,22 +15,49 @@ class PluginLoader {
         let pluginList = [];
         let plugins = [];
         let increment = 0;
-        FileSystem.readdirSync(directory).forEach(file => {
-            pluginList[increment] = file;
-            logger.info("Loaded " + file);
-            increment++;
+        FileSystem.readdirSync(directory).forEach(dirContent => {
+            if(FileSystem.lstatSync(directory + dirContent).isDirectory()){
+                if(FileSystem.readdirSync(directory + dirContent + "/")[0] != null) {
+                    pluginList[increment] = dirContent;
+                    logger.info("Loaded " + dirContent);
+                    increment++;
+                }
+            }
         })
         for(var i = 0; i < pluginList.length; i++) {
             var location = directory + pluginList[i] + "/";
             plugins[i] = require(location + pluginList[i]);
-            var manifest = JSON.parse(FileSystem.readFileSync(location + "manifest.json").toString());
-            plugins[i] = new plugins[i](manifest.name, manifest.description, manifest.permission, manifest.aliases, this.server);
-            this.server.getCommandMap().registerCommand(plugins[i]);
-            if(plugins[i].onEnable != null) {
-              plugins[i].onEnable();
+            if(FileSystem.existsSync(location + "manifest.json")) {
+                var manifest = JSON.parse(FileSystem.readFileSync(location + "manifest.json").toString());
+                manifest = this.checkManifest(manifest);
+                plugins[i] = new plugins[i](manifest.name, manifest.description, manifest.permission, manifest.aliases, this.server);
+                this.server.getCommandMap().registerCommand(plugins[i]);
+                if(plugins[i].onEnable != null) {
+                    plugins[i].onEnable();
+                }
+            } else {
+                throw new Error("No manifest found!");
             }
         }
     }
+
+    checkManifest(manifest){
+        if(manifest.name != null && manifest.name !== "") {
+            if(manifest.description == null) {
+                manifest.description = "No description";
+            }
+            if(manifest.permission == null) {
+                manifest.permission = "";
+            }
+            if(manifest.aliases == null) {
+                manifest.aliases = [];
+            }
+            return manifest;
+        } else {
+            throw new Error("No valid manifest name.");
+        }
+    }
+
 }
 
 module.exports = PluginLoader;


### PR DESCRIPTION
- Before loading a plugin dir in the plugins directory, make sure it
actually *is* a dir
- Make sure that the plugin dir isn’t empty
- Make sure that the plugin has a manifest
- Make sure the manifest is valid (has at least a name)
- If the manifest doesn’t have a description, permission, or aliases,
set them to a default value